### PR TITLE
fix: Skip prefix discovery in the file part of keys

### DIFF
--- a/src/glob_matcher/engine.rs
+++ b/src/glob_matcher/engine.rs
@@ -64,7 +64,6 @@ impl Engine for S3Engine {
         for prefix in prefixes {
             let client = self.client.clone();
             let bucket = self.bucket.clone();
-            let delimiter = self.delimiter.clone();
             let tx = tx.clone();
             let prefix = prefix.clone();
 
@@ -73,7 +72,6 @@ impl Engine for S3Engine {
                     .list_objects_v2()
                     .bucket(bucket)
                     .prefix(prefix.clone())
-                    .delimiter(delimiter)
                     .max_keys(1)
                     .send()
                     .await;


### PR DESCRIPTION
Only do prefix discovery at the end if it may help because there would
actually be prefixes generated. If we're looking for just plain files
and there are no more delimiters then a scan here is not better than a
scan in the main portion of the code.