### PR TITLE
refactor: move all matching and listing into glob/engine modules

### DIFF
--- a/src/glob_matcher/engine.rs
+++ b/src/glob_matcher/engine.rs
@@ -17,7 +17,7 @@ use tracing::info;
 
 use crate::{S3Object, add_atomic, progressln};
 
-use super::{LiveStatus, PrefixResult, PrefixSearchResult, S3GlobMatcher};
+use super::{LiveStatus, PrefixResult, PrefixSearchResult};
 
 #[async_trait::async_trait]
 pub trait Engine: Send + Sync + 'static {


### PR DESCRIPTION
The code is still sorta hard to understand, but at least it's now in the
right place.
