### PR TITLE
fix: Ensure that no non-matching prefixes are emitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.6](https://github.com/quodlibetor/s3glob/compare/v0.4.5...v0.4.6) - 2025-05-11
+
+### 🐛 Bug Fixes
+
+- Ensure that no non-matching prefixes are emitted by Brandon W Maister in [c289b8c](https://github.com/quodlibetor/s3glob/commit/c289b8c724a57c9d26f9a1fb715e2f4f028ad9cf)
+
 ## [0.4.5-prerelease.2](https://github.com/quodlibetor/s3glob/compare/v0.4.5-prerelease1...v0.4.5-prerelease.2) - 2025-05-04
 
 ### 📚 Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,7 +2459,6 @@ dependencies = [
  "aws-sdk-s3",
  "clap",
  "futures",
- "globset",
  "humansize",
  "itertools",
  "num-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ aws-config = "1.0"
 aws-sdk-s3 = "1.0"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 futures = "0.3"
-globset = "0.4"
 humansize = { version = "2.0.0", features = ["no_alloc"] }
 itertools = "0.14.0"
 num-format = "0.4"

--- a/src/glob_matcher/glob.rs
+++ b/src/glob_matcher/glob.rs
@@ -55,6 +55,10 @@ impl Glob {
         matches!(self, Glob::Choice { .. })
     }
 
+    pub(crate) fn is(&self, val: &str) -> bool {
+        matches!(self, Glob::Choice { allowed: alts, .. } if alts.len() == 1 && alts[0] == val)
+    }
+
     /// True if this is a negated character class `[!abc]`
     pub(crate) fn is_negated(&self) -> bool {
         matches!(self, Glob::Any { not: Some(_), .. })


### PR DESCRIPTION
For some reason the prefix-matching rules aren't exactly working
in some weird case. I can't reproduce it in minio, but this
does fix it.
