### PR TITLE
feat: Handle --format for prefixes, add a new {kind} format

### DIFF
--- a/src/glob_matcher.rs
+++ b/src/glob_matcher.rs
@@ -654,10 +654,16 @@ pub(crate) enum PrefixResult {
 }
 
 impl PrefixResult {
-    pub(crate) fn key(&self) -> &str {
+    pub(crate) fn kind(&self) -> String {
         match self {
-            Self::Object(obj) => &obj.key,
-            Self::Prefix(prefix) => prefix,
+            Self::Object(_) => "OBJ".to_owned(),
+            Self::Prefix(_) => "PRE".to_owned(),
+        }
+    }
+    pub(crate) fn key(&self) -> String {
+        match self {
+            Self::Object(obj) => obj.key.clone(),
+            Self::Prefix(prefix) => prefix.clone(),
         }
     }
 }

--- a/src/glob_matcher/engine.rs
+++ b/src/glob_matcher/engine.rs
@@ -351,12 +351,9 @@ impl Engine for MockS3Engine {
         let mut valid_prefixes = BTreeSet::new();
 
         for prefix in &prefixes {
-            // Use ListObjectsV2 with max-keys=1 to efficiently check existence
             let response = self.scan_prefixes_inner(prefix, "/")?;
 
-            if !response.prefixes.is_empty() {
-                valid_prefixes.insert(prefix.to_string());
-            } else if !response.objects.is_empty() {
+            if !response.prefixes.is_empty() || !response.objects.is_empty() {
                 valid_prefixes.insert(prefix.to_string());
             }
         }


### PR DESCRIPTION
The new {kind} format prints either OBJ or PRE for objects or prefixes, and means that `--format '{kind}  {uri}'` or `--format '{kind} {bucket}/{key}'` are more useful for copy/pasting from ls results into ls queries.