### PR TITLE
chore: Use BehaviorVersion::latest for aws client

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -567,7 +567,7 @@ impl S3Object {
 /// Create a new S3 client with region auto-detection
 async fn create_s3_client(opts: &Opts, bucket: &String) -> Result<Client> {
     let region = RegionProviderChain::first_try(Region::new(opts.region.clone()));
-    let mut config = aws_config::defaults(BehaviorVersion::v2025_08_07()).region(region);
+    let mut config = aws_config::defaults(BehaviorVersion::latest()).region(region);
     if opts.no_sign_request {
         config = config.no_credentials();
     }
@@ -587,7 +587,7 @@ async fn create_s3_client(opts: &Opts, bucket: &String) -> Result<Client> {
 
     let region = Region::new(bucket_region);
 
-    let mut config = aws_config::defaults(BehaviorVersion::v2025_08_07()).region(region);
+    let mut config = aws_config::defaults(BehaviorVersion::latest()).region(region);
     if opts.no_sign_request {
         config = config.no_credentials();
     }


### PR DESCRIPTION
We are not "reliant on extremely specific behavior characteristics"[^1], and can use whatever is available.

[^1]: https://docs.aws.amazon.com/sdk-for-rust/latest/dg/behavior-versions.html