### PR TITLE
feat: Add --force-path-style flag for S3-compatible servers accessed by hostname

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -262,6 +262,18 @@ struct Opts {
     /// concurrent requests.
     #[clap(short = 'M', long, global = true, default_value = "10000")]
     max_parallelism: usize,
+
+    /// Use path-style S3 addressing
+    ///
+    /// By default s3glob uses the standard virtualhost-style addressing,
+    /// where the bucket name is prepended to the endpoint hostname
+    /// (e.g. http://bucket.host/key).
+    ///
+    /// Use this flag when connecting to S3-compatible servers accessed by
+    /// hostname (e.g. MinIO at http://my.local.server:9000) that do not
+    /// support virtualhost-style addressing.
+    #[clap(long, global = true)]
+    force_path_style: bool,
 }
 
 fn main() {
@@ -578,7 +590,7 @@ async fn create_s3_client(opts: &Opts, bucket: &String) -> Result<Client> {
         config = config.http_client(platform_tls::build());
     }
     let config = config.load().await;
-    let client = Client::new(&config);
+    let client = build_s3_client(&config, opts.force_path_style);
 
     let res = client.head_bucket().bucket(bucket).send().await;
 
@@ -603,8 +615,16 @@ async fn create_s3_client(opts: &Opts, bucket: &String) -> Result<Client> {
         config = config.http_client(platform_tls::build());
     }
     let config = config.load().await;
-    let client = Client::new(&config);
+    let client = build_s3_client(&config, opts.force_path_style);
     Ok(client)
+}
+
+fn build_s3_client(config: &aws_config::SdkConfig, force_path_style: bool) -> Client {
+    Client::from_conf(
+        aws_sdk_s3::config::Builder::from(config)
+            .force_path_style(force_path_style)
+            .build(),
+    )
 }
 
 fn decimal_format() -> FormatSizeOptions {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -580,6 +580,48 @@ fn run_s3glob(port: u16, args: &[&str]) -> anyhow::Result<Command> {
     Ok(command)
 }
 
+/// Verifies that --force-path-style allows s3glob to work with a hostname
+/// endpoint, and that without it the command fails (because the SDK uses
+/// virtual-hosted-style, prepending the bucket name to the hostname, e.g.
+/// bucket.localhost, which does not resolve).
+#[tokio::test]
+async fn test_force_path_style() -> anyhow::Result<()> {
+    let (_node, port, client) = minio_and_client().await;
+
+    let bucket = "path-style-test";
+    client.create_bucket().bucket(bucket).send().await?;
+    create_object(&client, bucket, "test/object.txt").await?;
+
+    let pattern = format!("s3://{}/test/*", bucket);
+    let localhost_endpoint = format!("http://localhost:{}", port);
+
+    // With --force-path-style the SDK uses http://localhost:{port}/bucket/key
+    // and MinIO responds correctly.
+    let mut cmd =
+        s3glob_with_endpoint(&localhost_endpoint, &["ls", "--force-path-style", &pattern])?;
+    cmd.assert().success().stdout(contains("test/object.txt"));
+
+    // Without --force-path-style the SDK tries to reach
+    // http://path-style-test.localhost:{port}/test/* which does not resolve.
+    let mut cmd = s3glob_with_endpoint(&localhost_endpoint, &["ls", &pattern])?;
+    cmd.assert().failure();
+
+    Ok(())
+}
+
+fn s3glob_with_endpoint(endpoint: &str, args: &[&str]) -> anyhow::Result<Command> {
+    let mut command = assert_cmd::cargo::cargo_bin_cmd!("s3glob");
+    let log_directive = env::var("S3GLOB_LOG").unwrap_or_else(|_| "s3glob=trace".to_string());
+    command
+        .env("AWS_ENDPOINT_URL", endpoint)
+        .env("AWS_ACCESS_KEY_ID", "minioadmin")
+        .env("AWS_SECRET_ACCESS_KEY", "minioadmin")
+        .env("S3GLOB_LOG", log_directive)
+        .args(args);
+    print_s3glob_output(&mut command);
+    Ok(command)
+}
+
 #[tokio::test]
 async fn test_platform_tls_env_var() -> anyhow::Result<()> {
     let (_node, port, client) = minio_and_client().await;


### PR DESCRIPTION
S3-compatible servers like MinIO, when accessed by a hostname (e.g. http://myserver.local:9000 as opposed to IP address), require path-style addressing (http://host/bucket/key). By default, the AWS SDK uses virtual-hosted-style addressing, which prepends the bucket name to the hostname (http://bucket.host/key) — a hostname that typically won't resolve in local DNS, causing s3glob to fail even though the server itself is reachable.

The new --force-path-style flag opts into path-style addressing. Set it alongside AWS_ENDPOINT_URL when targeting a local or self-hosted S3-compatible server by hostname:

    AWS_ENDPOINT_URL=http://myserver.local:9000 s3glob ls --force-path-style 'my-bucket/**'

Note: when AWS_ENDPOINT_URL uses an IP address instead of a hostname, path-style is used automatically and this flag is not needed.

Fixes: #56