### PR TITLE
fix(matcher): fix deadlock in prefix discovery

### DIFF
--- a/src/glob_matcher.rs
+++ b/src/glob_matcher.rs
@@ -224,7 +224,7 @@ impl S3GlobMatcher {
                     // might have no prefixes if we only found objects before any prefixes
                     if scan_might_help && !prefixes.is_empty() {
                         debug!(part = %part.display(), "scanning for keys in an Any");
-                        let (tx, mut rx) = tokio::sync::mpsc::channel(prefixes.len());
+                        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
                         let mut tasks = Vec::new();
                         let semaphore = Arc::new(Semaphore::new(self.max_parallelism));
@@ -235,24 +235,23 @@ impl S3GlobMatcher {
                             let permit = semaphore.clone().acquire_owned().await;
                             let mut engine = engine.clone();
                             let prefix = prefix.clone();
-
-                            // if the prefix matches the regex, we can return it immediately
-                            if self.regex.is_match(&client_prefix) {
-                                tx.send(Ok((
-                                    prefix.clone(),
-                                    ScanResult::for_prefix(prefix.clone()),
-                                )))
-                                .await
-                                .unwrap();
-                            }
+                            let regex = self.regex.clone();
 
                             let task = tokio::spawn(async move {
+                                // if the prefix matches the regex, we can return it immediately
+                                if regex.is_match(&client_prefix) {
+                                    tx.send(Ok((
+                                        prefix.clone(),
+                                        ScanResult::for_prefix(prefix.clone()),
+                                    )))
+                                    .expect("send to unbounded channel always works");
+                                }
                                 match engine.scan_prefixes(&client_prefix, &delimiter).await {
                                     Ok(results) => {
-                                        let _ = tx.send(Ok((prefix, results))).await;
+                                        let _ = tx.send(Ok((prefix, results)));
                                     }
                                     Err(e) => {
-                                        let _ = tx.send(Err(e)).await;
+                                        let _ = tx.send(Err(e));
                                     }
                                 }
                                 drop(permit);


### PR DESCRIPTION
The find_prefixes Any branch built a bounded channel sized for one message per prefix, but the producer loop itself sent to the channel inline (when a prefix already matched the full regex) before spawning a task that would also send. With small/fast S3 backends a spawned scan_prefixes could complete during the loop, fill the buffer, and block the producer's next inline send. No consumer ran until the producer loop finished, so this self-deadlocked.

This refactor removes the producer-self-send entirely: the regex check and immediate match are moved inside the spawned task, so only spawned tasks ever send to the channel. The producer just spawns and then drains. The deadlock shape is structurally impossible regardless of channel kind.

It's always possible that there's more, but I haven't seen timeouts since discovering this.

Fixes: #72